### PR TITLE
ci: add workflow to detect and close stale PRs [skip ci]

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '30 6 * * *' # 6:30 am UTC: 1:30 am EST
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          days-before-stale: 30
+          days-before-close: 60
+          stale-pr-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs.
+          close-pr-message: >
+            This issue has been automatically closed because it has had no activity
+            for over 90 days. Please re-open if you feel this was done in error.
+          exempt-pr-labels: 'dependabot,depfu,dependencies,security'


### PR DESCRIPTION
#### Why
This workflow will mark your PRs as `stale` after 30 days of no activity.
After an additional 60 days of no activity, it will close the PR.

#### What changed
* introduce new `stale` workflow that uses a Github Action to automatically mark PRs as stale and eventually close them: https://github.com/actions/stale

More context: https://wealthsimple.atlassian.net/browse/TOOLS-828

