### PR TITLE
fix: [DEVREQ-381] Update Bundler to prevent CVE-2020-36327

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,4 +32,4 @@ DEPENDENCIES
   string-obfuscator!
 
 BUNDLED WITH
-   2.2.29
+   2.3.20

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,35 @@
+PATH
+  remote: .
+  specs:
+    string-obfuscator (0.1.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.5.0)
+    rake (10.5.0)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.12)
+  rake (~> 10.0)
+  rspec (~> 3.0)
+  string-obfuscator!
+
+BUNDLED WITH
+   2.2.29


### PR DESCRIPTION

### Why

https://wealthsimple.atlassian.net/browse/DEVREQ-381?atlOrigin=eyJpIjoiM2I4OTI1M2EwMTE2NGQxOTk1YzY2NmRjYmYwMzhmZGMiLCJwIjoiaiJ9

### What is changing

New gemfile.lock with Bundler 2

